### PR TITLE
[fix] 헤더 내용 변경 및 기본 페이지를 재생에너지 전환율 페이지로 가게 만듬

### DIFF
--- a/eco-location/src/AppRouter.js
+++ b/eco-location/src/AppRouter.js
@@ -1,7 +1,7 @@
 import React from "react";
 import "./css/index.css";
 
-import { BrowserRouter, Routes, Route} from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate} from "react-router-dom";
 
 import Header from "./Header.js"
 
@@ -21,25 +21,26 @@ class AppRouter extends React.Component {
                 <Header/>
                 <div>
                     <Routes>
-                        {/* <Route path="/" element={<TestPage />}></Route> */}
+                        {/* 기본 페이지는 재생에너지 전환율 페이지로 */}
+                        <Route path="/" element={<Navigate to="/renewable-percent" />} />
                         
                         {/* 과거 재생에너지 발전량 */}
-                        {/* <Route path="/Gen_total" element={<Gen_total />}></Route> */}
-                        {/* <Route path="/Gen_year" element ={<Gen_year />}></Route> */}
-                        {/* <Route path="/Gen_detail" element ={<Gen_detail />}></Route> */}
+                        {/* <Route path="/gen-total" element={<Gen_total />}></Route> */}
+                        {/* <Route path="/gen-year" element ={<Gen_year />}></Route> */}
+                        {/* <Route path="/gen-detail" element ={<Gen_detail />}></Route> */}
 
                         {/* 재생에너지 잠재력 확인 */}
-                        <Route path="/potential_total" element={<TotalPotential/>}></Route>
-                        <Route path="/potential_year" element={<YearPotential/>}></Route>
+                        <Route path="/potential-total" element={<TotalPotential/>}></Route>
+                        <Route path="/potential-year" element={<YearPotential/>}></Route>
                         
                         {/* 기존 발전소 */}
-                        <Route path="/exist_gen" element={<Exist_Gen/>}></Route>
+                        <Route path="/exist-gen" element={<Exist_Gen/>}></Route>
 
                         {/* 재생에너지 전환율 */}
-                        <Route path="/renewable_percent" element={<Renewable_percent/>}></Route>
+                        <Route path="/renewable-percent" element={<Renewable_percent/>}></Route>
 
                         {/* API 테스트용 페이지 */}
-                        <Route path="/test_page" element={<API_Test_Page/>}></Route>
+                        <Route path="/test-page" element={<API_Test_Page/>}></Route>
 
                     </Routes>
                 </div>

--- a/eco-location/src/Header.js
+++ b/eco-location/src/Header.js
@@ -8,34 +8,25 @@ class Header extends React.Component {
             <div className="headerContainer">
                 <div className="nav">
                     <div className="item">
-                        <Link to="/">에코로케이션</Link>
-                    </div>
-                    <div className="item">
-                        <Link to="/Gen_total">과거 재생에너지 발전량</Link>
+                        <Link to="/gen-total">과거 재생에너지 발전량</Link>
                         <div className="dropdown">
-                            <Link to="/Gen_total">지역별 발전량</Link>
-                            <Link to="/Gen_year">연도별 발전량</Link>
-                            <Link to="/Gen_detail">지역별 발전량 상세</Link>
+                            <Link to="/gen-total">지역별 발전량</Link>
+                            <Link to="/gen-year">연도별 발전량</Link>
+                            <Link to="/gen-detail">지역별 발전량 상세</Link>
                         </div>
                     </div>
                     <div className="item">
-                        <Link to="/potential_total">재생에너지 잠재량 확인</Link>
+                        <Link to="/potential-total">재생에너지 잠재량 확인</Link>
                         <div className="dropdown">
-                            <Link to="/potential_total">지역별 잠재량</Link>
-                            <Link to="/potential_year">시간별 잠재량</Link>
+                            <Link to="/potential-total">지역별 잠재량</Link>
+                            <Link to="/potential-year">시간별 잠재량</Link>
                         </div>
                     </div>
                     <div className="item">
-                        <Link to="/exist_gen">기존 발전소</Link>
-                        <div className="dropdown">
-                            <Link to="/exist_gen">지역별 발전소 확인</Link>
-                        </div>
+                        <Link to="/exist-gen">기존 발전소 확인</Link>
                     </div>
                     <div className="item">
-                        <Link to="/renewable_percent">재생에너지 전환율</Link>
-                        <div className="dropdown">
-                            <Link to="/renewable_percent">국내 재생에너지 생산비율</Link>
-                        </div>
+                        <Link to="/renewable-percent">재생에너지 전환율</Link>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
- '/' 를 '/renewable-percent' 로 Navigate되도록 함
- 링크 이름 중 _에서 -로 바꿈
- 헤더 내용을 페이지에 맞게 고침